### PR TITLE
Add hash routing for individual bug pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,32 @@ let constants = null;
 let originalBugs = null;
 let currentBugs = null;
 
+// ========== Routing ==========
+
+function getCurrentBugId() {
+    const hash = window.location.hash.slice(1); // Remove '#'
+    return hash || null;
+}
+
+function getBugIndexById(id) {
+    if (!currentBugs || !id) return -1;
+    return currentBugs.findIndex(bug => bug.id === id);
+}
+
+function navigateToBug(bugId) {
+    window.location.hash = bugId;
+}
+
+function navigateToAll() {
+    history.pushState('', document.title, window.location.pathname);
+    handleRouteChange();
+}
+
+function handleRouteChange() {
+    if (!currentBugs) return; // Data not loaded yet
+    renderAll();
+}
+
 // ========== Data Loading ==========
 
 async function loadData() {
@@ -481,6 +507,7 @@ function renderBugCard(bug, impact, index) {
             </div>
             <p class="bug-date">${formatDate(bug.reportedDate)} · <strong>${impact.yearsUnfixed} years unfixed by Apple</strong></p>
             ${bug.sourceUrl ? `<p class="bug-source">Source: <a href="${bug.sourceUrl}" target="_blank">${bug.sourceLabel || bug.sourceUrl}</a></p>` : ''}
+            <a href="#${bug.id}" class="bug-permalink" title="Link to this bug">🔗 Permalink</a>
         </footer>
     `;
 
@@ -500,6 +527,29 @@ function renderAll() {
     const container = document.getElementById('bugs-container');
     container.innerHTML = '';
 
+    const currentBugId = getCurrentBugId();
+    const singleBugIndex = getBugIndexById(currentBugId);
+
+    // Single bug view
+    if (singleBugIndex !== -1) {
+        const backLink = document.createElement('a');
+        backLink.href = '#';
+        backLink.className = 'back-to-all';
+        backLink.textContent = '← Back to all bugs';
+        backLink.onclick = (e) => {
+            e.preventDefault();
+            navigateToAll();
+        };
+        container.appendChild(backLink);
+
+        const card = renderBugCard(currentBugs[singleBugIndex], impacts[singleBugIndex], singleBugIndex);
+        container.appendChild(card);
+
+        updateTotalImpact([impacts[singleBugIndex]]);
+        return;
+    }
+
+    // All bugs view
     currentBugs.forEach((bug, index) => {
         const card = renderBugCard(bug, impacts[index], index);
         container.appendChild(card);
@@ -517,6 +567,9 @@ async function main() {
 
         // Add global click handler for editable values
         document.addEventListener('click', handleEditableClick);
+
+        // Handle hash changes for routing
+        window.addEventListener('hashchange', handleRouteChange);
 
     } catch (error) {
         console.error('Failed to load data:', error);

--- a/styles.css
+++ b/styles.css
@@ -668,6 +668,32 @@ body {
     text-decoration: underline;
 }
 
+.bug-permalink {
+    font-size: 13px;
+    color: var(--text-tertiary);
+    text-decoration: none;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+}
+
+.bug-permalink:hover {
+    opacity: 1;
+    color: var(--accent);
+}
+
+/* Back to all bugs link */
+.back-to-all {
+    display: inline-block;
+    margin-bottom: var(--space-xl);
+    color: var(--accent);
+    text-decoration: none;
+    font-size: 15px;
+}
+
+.back-to-all:hover {
+    text-decoration: underline;
+}
+
 /* ========== Footer ========== */
 .footer {
     padding: var(--space-2xl) var(--container-padding);


### PR DESCRIPTION
- URLs like bugsappleloves.com/#mail-search show single bug
- Each bug card has a permalink link
- Back to all bugs link when viewing single bug
- Hash changes handled for browser back/forward

## What bug are you adding?

<!-- Brief description of the Apple bug -->

## How long has it been unfixed?

<!-- Rough estimate is fine -->

## Any evidence?

<!-- Optional: links to forum posts, Reddit threads, articles, etc. -->
